### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
-#APIMASH Starter Kits
+# APIMASH Starter Kits
 
 
 ----------
 
 
-##Description
+## Description
 APIMASH Starter Kits for Windows demonstrate how to use public Web Service API's such as Edmunds, Tom-Tom, Twitter, Tumblr, Yelp, Meetup and many others to create Windows 8 Store Apps. These Starter Kits will put you on the fast path to publishing your first App to the Windows Store.
 
-###Pre-reading
+### Pre-reading
 
  - [Creating Compelling Windows 8 Apps  using API's][1]
  - [JSON Deserialization for C#  Developers][2]
  - [APIMASH on Channel 9][3]
 
-##API Partners
+## API Partners
 
 ![alt text][4]
 [Mashery][5]
 
-##Starter Kits for Windows 8.1
+## Starter Kits for Windows 8.1
 
  1. [EchoNest API (XAML/C#)][23]
 
-##Starter Kits for Windows 8
+## Starter Kits for Windows 8
 
  1. [Active Access (HTML5/JS)][6]
  2. [Chuck Norris (XAML/C#)][7]
@@ -46,7 +46,7 @@ APIMASH Starter Kits for Windows demonstrate how to use public Web Service API's
  20. ESPN (HTML/JS)
  
 
-##Starter Kits for Windows Phone 8
+## Starter Kits for Windows Phone 8
 
  1. [Chuck Norris (XAML/C#)][18]
  2. [Chuck Norris (XAML/VB)][25]
@@ -59,11 +59,11 @@ APIMASH Starter Kits for Windows demonstrate how to use public Web Service API's
  9. Earthquakes (HTML5/JS)
 
 
-##1 - Download the Starter Kits
+## 1 - Download the Starter Kits
    
-##2 - Customize the API calls and Update the User Experience
+## 2 - Customize the API calls and Update the User Experience
  
-##3 - Submit your App to the Windows Store
+## 3 - Submit your App to the Windows Store
 
 
   [1]: http://theundocumentedapi.com/2013/05/28/apimash-using-apis-to-create-compelling-windows-apps/

--- a/Windows 8.1 Starter Kits/APIMASH_EchoNest_StarterKit/readme.md
+++ b/Windows 8.1 Starter Kits/APIMASH_EchoNest_StarterKit/readme.md
@@ -1,36 +1,36 @@
-#APIMASH EchoNest Starter Kit
-##Date: 8.08.2013
-##Version: v1.0.0
-##Author(s): Steve Maier
-##URL: http://github.com/apimash/starterkits
+# APIMASH EchoNest Starter Kit
+## Date: 8.08.2013
+## Version: v1.0.0
+## Author(s): Steve Maier
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The EchoNest Starter Kit is a XAML/C# Windows 8 app that demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 
 [See this article for details on the EchoNest Starter Kit][1]
 
 ![alt text][2]
 
-###Features
+### Features
  - Invokes the EchoNest API (http://the.echonest.com/)
  - Demonstrates how to deserialize JSON to C#
  - Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 
  - Windows 8.1
  - Visual Studio 2013 Preview
  - Developer API Key from EchoNest 
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from (http://apimash.github.io/StarterKits/)
  - Open the EchoNest Solution in Visual Studio 2013
  - Change the APIKEY variable in the APIMash_EchoNest.cs file
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -39,8 +39,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]:  http://42base13.net/apimash-echonest-starter-kit/

--- a/Windows Phone Starter Kits/APIMASH_CNorris_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_CNorris_StarterKit_Phone/readme.md
@@ -1,23 +1,23 @@
-#APIMASH Chuck Norris Starter Kit for Windows Phone
-##Date: 6.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar
-##URL: http://github.com/apimash/starterkits
+# APIMASH Chuck Norris Starter Kit for Windows Phone
+## Date: 6.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Chuck Norris Starter Kit for Windows Phone is a XAML/C# Windows Phone 8 app that demonstrates calling a Web Service that returns a simple JSON payload. The JSON payload is deserialized into a View Model and displayed on the screen.
 
 [See this article for details on the Chuck Norris Starter Kit][1]
 
 ![alt text][2]
 
-###Features
+### Features
  - Invokes the [Internet Chuck Norris Database][3] API
  - [Demonstrates how to deserialize JSON to C#][4]
  - Provides a baseline for a [Windows Phone 8 Store App][5]
 
-###Requirements
+### Requirements
 
  - Windows 8
  - [Visual Studio 2012 Express for Windows Phone][6]
@@ -25,7 +25,7 @@ The Chuck Norris Starter Kit for Windows Phone is a XAML/C# Windows Phone 8 app 
  - [JSON.NET form Newtonsoft][8]
 
 
-###Setup
+### Setup
     
 
  - Download the [Starter Kit Portfolio][9]
@@ -33,7 +33,7 @@ The Chuck Norris Starter Kit for Windows Phone is a XAML/C# Windows Phone 8 app 
  - Update the reference to the JSON.NET Library in the APIMASHLib project
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -42,8 +42,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]: http://theundocumentedapi.com/index.php/apimash-chuck-norris-starter-kit-for-windows-phone-8/

--- a/Windows Phone Starter Kits/APIMASH_CNorris_VB_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_CNorris_VB_StarterKit_Phone/readme.md
@@ -1,11 +1,11 @@
-#APIMASH Chuck Norris VB Starter Kit for Windows Phone
-##Date: 6.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar, ported to VB by Dave Noderer
-##URL: http://github.com/apimash/starterkits
+# APIMASH Chuck Norris VB Starter Kit for Windows Phone
+## Date: 6.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar, ported to VB by Dave Noderer
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Chuck Norris Starter Kit for Windows Phone is a XAML/vb.net Windows Phone 8 app that demonstrates calling a Web Service that returns a simple JSON payload. The JSON payload is deserialized into a View Model and displayed on the screen.
 
 [See this article for details on the Chuck Norris Starter Kit][1]
@@ -14,12 +14,12 @@ The Chuck Norris Starter Kit for Windows Phone is a XAML/vb.net Windows Phone 8 
 
 ![alt text][2]
 
-###Features
+### Features
  - Invokes the [Internet Chuck Norris Database][3] API
  - [Demonstrates how to deserialize JSON to C#][4]
  - Provides a baseline for a [Windows Phone 8 Store App][5]
 
-###Requirements
+### Requirements
 
  - Windows 8
  - [Visual Studio 2012 Express for Windows Phone][6]
@@ -27,7 +27,7 @@ The Chuck Norris Starter Kit for Windows Phone is a XAML/vb.net Windows Phone 8 
  - [JSON.NET form Newtonsoft][8]
 
 
-###Setup
+### Setup
     
 
  - Download the [Starter Kit Portfolio][9]
@@ -35,7 +35,7 @@ The Chuck Norris Starter Kit for Windows Phone is a XAML/vb.net Windows Phone 8 
  - Update the reference to the JSON.NET Library in the APIMASHLib project
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -44,9 +44,9 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
-###v1.0.1
+## Change Log
+### v1.0.0
+### v1.0.1
 Initial Port to vb.net
 
 

--- a/Windows Phone Starter Kits/APIMASH_Earthquakes_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_Earthquakes_StarterKit_Phone/readme.md
@@ -1,27 +1,27 @@
 ﻿#APIMASH Earthquake App for Windows Phone
-##Date: 7.8.2013
-##Version: v1.0.1
-##Author(s): Brian Hitney
-##URL: http://github.com/apimash/starterkits
+## Date: 7.8.2013
+## Version: v1.0.1
+## Author(s): Brian Hitney
+## URL: http://github.com/apimash/starterkits
 
 
 ![alt text][1]
-###Description
+### Description
 This application loads earthquake data from the USGS and displays a pushpin for each earthquake on Bing maps.  For more information on the Bing Maps SDK, visit [this page on MSDN][2].
 
-###Features
+### Features
 - Uses both USGS and Bing maps.
 
-###Requirements 
+### Requirements 
  - Visual Studio 2012 Express for Windows Phone 8 or higher 
  - Bing Maps API Key (sign up [here][3] - Microsoft Account required for the Bing Maps Portal)
 
-###Setup
+### Setup
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -32,11 +32,11 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
+## Change Log
 
-###v1.0.1
+### v1.0.1
 -  Fixed screenshot
-###v1.0.0
+### v1.0.0
  - Initial check-in
 
 

--- a/Windows Phone Starter Kits/APIMASH_EchoNest_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_EchoNest_StarterKit_Phone/readme.md
@@ -1,23 +1,23 @@
-#APIMASH EchoNest Starter Kit for Windows Phone
-##Date: 8.19.2013
-##Version: v1.0.0
-##Author(s): Steve Maier
-##URL: http://github.com/apimash/starterkits
+# APIMASH EchoNest Starter Kit for Windows Phone
+## Date: 8.19.2013
+## Version: v1.0.0
+## Author(s): Steve Maier
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The EchoNest Starter Kit is a XAML/C# Windows 8 app that demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 
 [See this article for details on the EchoNest Starter Kit][1]
 
 ![alt text][2]
 
-###Features
+### Features
  - Invokes the [EchoNest][3] API
  - Demonstrates how to deserialize JSON to C#
  - Provides a baseline for a [Windows Phone 8 Store App][4]
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012
@@ -25,14 +25,14 @@ The EchoNest Starter Kit is a XAML/C# Windows 8 app that demonstrates calling a 
  - [JSON.NET form Newtonsoft][6]
  - Developer API Key from EchoNest 
 
-###Setup
+### Setup
 
  - Download the [Starter Kit Portfolio][7]
  - Open the EchoNest Phone Solution in Visual Studio 2012
  - Change the APIKEY variable in the APIMash_EchoNest.cs file
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -41,8 +41,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]: http://42base13.net/echonest-wp8/

--- a/Windows Phone Starter Kits/APIMASH_Edmunds_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_Edmunds_StarterKit_Phone/readme.md
@@ -1,23 +1,23 @@
-#APIMASH Edmunds Starter Kit for Windows Phone
-##Date: 6.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar
-##URL: http://github.com/apimash/starterkits
+# APIMASH Edmunds Starter Kit for Windows Phone
+## Date: 6.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar
+## URL: http://github.com/apimash/starterkits
 
 ----------
-##Description
+## Description
 The Edmunds Starter Kit for Windows Phone is a XAML/C# Windows Phone 8 app that demonstrates calling the Edmunds REST API's. The JSON payload for Makes, Models, Model Specs and Pictures is deserialized into a set of C# classes that define the Data Model. That data then is selectively copied into the View Model for binding to XAML controls. You can use the breadth and detail of the automotive information available through the Edmunds API to create mashups, visualizations and other applications that will provide an added dimension of user experience for the automotive consumer.
 
 Blog: [APIMASH Edmunds Starter Kit for Windows Phone][1]
 
 ![alt text][2]
 
-##Features
+## Features
  - Invokes the [Edmunds REST API][3]
  - Demonstrates how to deserialize JSON to C# and bind to XAML Controls
  - Provides a baseline for a Windows 8 Phone Store App
 
-##Requirements
+## Requirements
 
  - Windows 8
  - [Visual Studio 2012 Express for Windows Phone 8][4]
@@ -25,7 +25,7 @@ Blog: [APIMASH Edmunds Starter Kit for Windows Phone][1]
  - [Mashery.com Developer Account][6]
  - [Edmunds Developer Key][7]
 
-##Setup
+## Setup
 
  - [Register at Mashery.com][8]
  - [Request a Developer Key at Edmunds][9]
@@ -35,7 +35,7 @@ Blog: [APIMASH Edmunds Starter Kit for Windows Phone][1]
  - Update the reference to the *Newtonsoft JSON.NET Library* in the *APIMASHLib* project
  - Compile and Run
 
-##Customization
+## Customization
 
 The Edmunds API, one a scale of 1 to 10, where 1 is simple and 10 is complex, is an 11 :). Edmunds provides a rich set of API collections each with several API's and methods that give you access to Articles, Vehicle Data, Dealer info and Inventory data that can be used together or with other API's to create compelling apps.
 
@@ -91,7 +91,7 @@ The Model Year Repository API also provides these methods:
 
 You can also experiment with adding in the Editorial or Dealer API's to add color commentary and availability information.
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 

--- a/Windows Phone Starter Kits/APIMASH_Instagram_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_Instagram_StarterKit_Phone/readme.md
@@ -1,23 +1,23 @@
-#APIMASH Instagram Starter Kit for Windows Phone 8.0
-##Date: 7.30.2013
-##Version: v1.0.0
-##Author(s): Stacey Mulcahy
-##URL: http://github.com/apimash/starterkits
+# APIMASH Instagram Starter Kit for Windows Phone 8.0
+## Date: 7.30.2013
+## Version: v1.0.0
+## Author(s): Stacey Mulcahy
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Instagram Starter Kit for Windows Phone uses the Instagram api and illustrates how to use many of the endpoints that do not require authorization. It is an HTML5/js application for the Windows Phone. All calls do require a client id however.
 ![My image](image.png) 
 ![My image](image1.png) 
 ![My image](image2.png) 
-###Features
+### Features
  - Invokes the Instagram API (http://instagram.com/developer/)
  - Enables various endpoints including tags, location, media and popular. 
  - Demonstrates how to use the winjs list component
  - Provides a baseline for a Windows 8 Phone Application
  - For API documentation, please see http://instagram.com/developer/
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
@@ -25,7 +25,7 @@ The Instagram Starter Kit for Windows Phone uses the Instagram api and illustrat
  - Instagram application key ( client id ) http://instagram.com/developer/
  - Utilizes jQuery version 2.0.0 (http://code.jquery.com/jquery-2.0.0.js)
 
-###Setup
+### Setup
 
  - Register with Instagram and register a new application ( http://instagram.com/developer/clients/manage/)
  - Keep track of the client id once you have registered.
@@ -35,7 +35,7 @@ The Instagram Starter Kit for Windows Phone uses the Instagram api and illustrat
  - Compile and Run
  **NOTE**: You will need to add your own developer signing certificate to the project, by opening the package.appxmanifest file, and switching to the Packaging tab. On the packaging tab, click the "Choose Certificate..." button, and in the resulting dialog, click the "Configure Certificate..." drop-down, and select "Create test certificate..." then click OK to dismiss all dialogs, and save the app manifest file.
 
-###Customization
+### Customization
 This example exposes all the endpoints at their most basic level. Most of the endpoints do not have options, but a few do that include things like distance( for geolocation) or the max and min ideas for any endpoint that is getting recent media. Please see the Instagram API documentation - these parameters can be passed in through the calls via the options parameter, which is an object. 
 
 As some photos do carry geolocation information with them ( its a user's preference to add geolocation), mash ups with Maps are ideal. This template also provides and easy way to aggregate and show photos tagged with a specific hashtag, or that are in a location - making it an ideal complement to apis such as Yelp, Foursquare and Meetup to name a few. 
@@ -50,11 +50,11 @@ App Ideas:
 
 ----------
 
-##Change Log
-###v1.0.1
+## Change Log
+### v1.0.1
 - Modified readme
 
-##DISCLAIMER: 
+## DISCLAIMER: 
  
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
  

--- a/Windows Phone Starter Kits/APIMASH_MeetupMaps_StarterKit/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_MeetupMaps_StarterKit/readme.md
@@ -1,25 +1,25 @@
-#Meetup and Maps Starter Kit
-##Date: 07/26/2013
-##Version: v0.0.1
-##Author(s): G. Andrew Duthie
-##URL: http://github.com/apimash/starterkits
+# Meetup and Maps Starter Kit
+## Date: 07/26/2013
+## Version: v0.0.1
+## Author(s): G. Andrew Duthie
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Meetup and Maps Starter Kit is a Windows Phone 8 app based on the Databound App template. It leverages the Meetup.com API to search for upcoming meetups near a given location, with optional keyword filtering. Once the meetups are retrieved, the starter kit maps a selected item, and queries the Bing Maps Search API for nearby coffee shops, and maps those as well.
 
 ![alt text][1]
 
-###Features
+### Features
  - Demonstrates using System.Net.WebClient to call the [Meetup.com API][2]
  - Demonstrates integrating the [Maps API][3], and leveraging the [MapsTask][4] object to find local points of interest
  - Demonstrates how to use Linq to XML to load live data into the Databound App template, and how to adapt the live data to display with minimal customization to the XAML and C# files in the template
 
-###Requirements
+### Requirements
  - Meetup API Key (don't use your day-to-day meetup ID for this...create a unique account, and sign up for a key [here][5])
  - Windows Phone Marketplace Account (to submit app for certification)
 
-###Setup and Customization
+### Setup and Customization
 Basic customization is done via the file AppConstants.cs, found in the Customiztion folder. Here are the key items you can customize:
 
  - meetupUri: base uri for the Meetup API to be called
@@ -33,10 +33,10 @@ Basic customization is done via the file AppConstants.cs, found in the Customizt
  
 More advanced customization is possible by digging into the code and XAML. All logic for retrieving and grouping Meetup data may be found in ViewModels\MainViewModel.cs.
 
-###Known Issues
+### Known Issues
 Here are the currently known issues (aka learning opportunities for the developer):
 
-##**DISCLAIMER**: 
+## **DISCLAIMER**: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -46,8 +46,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v0.0.1
+## Change Log
+### v0.0.1
 
  - initial release
 

--- a/Windows Phone Starter Kits/APIMASH_TomTom_StarterKit_Phone/README.md
+++ b/Windows Phone Starter Kits/APIMASH_TomTom_StarterKit_Phone/README.md
@@ -1,33 +1,33 @@
-#APIMASH TomTom Starter Kit for Windows Phone
-##Date: 7.4.2013
-##Version: v1.0.0
-##Author(s): Jim O'Neil
-##URL: http://github.com/apimash/starterkits
+# APIMASH TomTom Starter Kit for Windows Phone
+## Date: 7.4.2013
+## Version: v1.0.0
+## Author(s): Jim O'Neil
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The TomTom Starter Kit is a XAML/C# Windows Phone 8 map-based application that overlays locations of traffic cameras across the US and Canada as provided by [TomTom][1].  The application has been built to easily display geocoded points-of-interest obtained from other APIs.
 
 ![Traffic Cam application](Screenshot.png)
 
-###Features
+### Features
  - Invokes the [TomTom Traffic Cameras API][2]
  - Demonstrates how to deserialize XML to C#
  - Provides a baseline for a Windows Phone 8 App
 
-###Requirements
+### Requirements
 
  - Windows 8 (64-bit Professional version or higher)
  - [Visual Studio 2012 Express for Windows Phone][3] or higher
  - [Mashery ID to access TomTom Developer Portal][4] and obtain API license key
 
-###Setup
+### Setup
 
  - Download the [Starter Kit Zip Portfolio][5] 
  - Navigate to the **APIMASH\_TomTom\_StarterKit\_Phone** directory and open the solution there
  - Paste your TomTom Traffic Cam API key into designated portion of the **App.xaml** file
 
-###Customization
+### Customization
 This starter kit was built in a modular manner to make it easy to integrate just about any API that has elements exposing latitude and longitude. The map implementation already includes necessary 
 logic for showing point-of-interest pins and marking your current location as determined by GPS.
 
@@ -39,7 +39,7 @@ Minimally, you'll need to do two things:
  2. Modify **MainPage.xaml** and its code-behind to data bind to your API's view model, adapting the layout to show the details of the point-of-interest selected on the map.
 
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -47,8 +47,8 @@ Microsoft and I do not warrant, guarantee or make any representations regarding 
 Microsoft and I shall not be liable for any direct, indirect or consequential damages or costs of any type arising out of any action taken by you or others related to the sample code.
 
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 [1]:http://www.tomtom.com "TomTom"
 [2]:http://developer.tomtom.com/docs/read/traffic_cameras "TrafficCam API"

--- a/Windows Phone Starter Kits/APIMASH_WoWAPI_StarterKit_Phone/readme.md
+++ b/Windows Phone Starter Kits/APIMASH_WoWAPI_StarterKit_Phone/readme.md
@@ -1,11 +1,11 @@
 ﻿#APIMASH Windows Phone 8 World of Warcraft API Kit
-##Date: 6.25.2013
-##Version: v1.0.0
-##Author(s): David Isbitski
-##URL: https://github.com/apimash/StarterKits/blob/master/Windows%20Phone%20Starter%20Kits/APIMASH_WoWAPI_StarterKit_Phone
+## Date: 6.25.2013
+## Version: v1.0.0
+## Author(s): David Isbitski
+## URL: https://github.com/apimash/StarterKits/blob/master/Windows%20Phone%20Starter%20Kits/APIMASH_WoWAPI_StarterKit_Phone
 
 ----------
-###Description
+### Description
 The Windows Phone 8 World of Warcraft API Kit is intended to teach Windows developers how to incorporate the World of Warcraft APIs into their own apps.
 This Kit is for educational and entertainment purposes only.  World of Warcraft is a very successful online game from Blizzard Entertainment®.   
 Blizzard Entertainment® is the copyright holder to all World of Warcraft content and images used in this application.
@@ -13,7 +13,7 @@ Blizzard Entertainment® is the owner of the World of Warcraft API which can be 
 
 ![alt text][1]![alt text][2]![alt text][3]
 ![alt text][4]
-###Features
+### Features
 WoW API
   - Realm Status (individual)
   - Realm Status (all)
@@ -27,18 +27,18 @@ Windows Phone App
   - Calling HTML5/JS from C#
   - Small and Medium Tiles
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows Phone or higher
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from (http://apimash.github.io/StarterKits/)
  - Open the Solution in Visual Studio
  - Compile and Run
 
-###Customization
+### Customization
 
 Step 1. All of the Blizzard World of Warcraft API's do not require a developer key to use.  However, if you plan on creating an application with heavy api usage Blizzard requests you contact them at api-support@blizzard.com to register your application.
 
@@ -47,7 +47,7 @@ Step 2. Currently only Realm Status is implemented.  Adding additional functiona
 Step 3. Once you have data returning you should load the results into a Web Browser Control using divs similar to /html/index.html.  
 
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -62,8 +62,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0 - Updated to point to new license file
+## Change Log
+### v1.0.0 - Updated to point to new license file
 
 
   [1]: https://raw.github.com/disbitski/WP8WoWAPIKit/master/AllRealms.png "All Realms"

--- a/Windows Starter Kits/APIMASH_ACTIVEACESS API/readme.md
+++ b/Windows Starter Kits/APIMASH_ACTIVEACESS API/readme.md
@@ -1,12 +1,12 @@
-#Title:  ACTIVE ACCESS APIMASHUP STARTKIT
+# Title:  ACTIVE ACCESS APIMASHUP STARTKIT
 Active Access APIMASHUP STARTERKIT 
-##Date: 2/30/2013
-##Version: v0.0.2
-##Author(s): Maria Naggaga
+## Date: 2/30/2013
+## Version: v0.0.2
+## Author(s): Maria Naggaga
 
 
 ----------
-###Description
+### Description
 
 The Active Access Starter Kit is an HTML5 and JS  Windows 8 App  using the blank template. It leverages the Active Access API to populate a sporting , camping, concert etc based on a geographical location. 
 APIMASH_ACTIVEACCESS API_StarterKit shows you how to interact with an external webservice((in this case Active Access API) using the datadapter, Binding.ListAPI , ListDataSourceAPI, and how to display the grouped data using custom group and item datasources. 
@@ -20,14 +20,14 @@ This specific example uses XmlHttpRequest
  to access the Active Access search feature of <a href="http://developer.active.com"> [Active Access][2]</a>
  which is exposed as a web service.Key Rates Limits: 2 call per second and 10,000 calls per day.
 
-###Features
+### Features
  -  Make Calls to the  Active Access API - [WinJS.xhr][3] 
  - Creates a custom [IListDataAdapter][4] that connects to a web service and displays the data in a [ListView][5] control.
  -Implements the IListDataAdapter interface and creates a custom IListDataSource by inheriting from the [VirtualizedDataSource][6] calls. 
 
 
  
-###Requirements
+### Requirements
 
  - [Sign up for Mashery API Developers Key][7]
  - [Active Access Search API Key][8]
@@ -36,12 +36,12 @@ This specific example uses XmlHttpRequest
 
  
 
-###Setup
+### Setup
 
  1. Step 1 : Setup your developer's environment.  Install  Windows 8 and Visual Studio 2012. If you are on a Mac [Download a VM][10] .
  2. Step 2: Download the Starter Kits from [Github][11]
 
-###Kit Customization 
+### Kit Customization 
 
  1. Open the ActiveAccessAPI.JSGo to the
     getCount:Function ( ) edit the following: 
@@ -115,8 +115,8 @@ Search Results
 ----------
 
 
-##Change Log
-###v0.0.0
+## Change Log
+### v0.0.0
 Add version data here
 
 

--- a/Windows Starter Kits/APIMASH_CNorris_StarterKit/APIMASH_CNorris_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_CNorris_StarterKit/APIMASH_CNorris_StarterKit/readme.md
@@ -1,26 +1,26 @@
-#APIMASH Chuck Norris Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar
-##URL: http://github.com/apimash/starterkits
+# APIMASH Chuck Norris Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Chuck Norris Starter Kit is a XAML/C# Windows 8 app that demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 
 
-###Features
+### Features
  - Invokes the Internet Chuck Norris Database API (http://www.icndb.com/)
  - Demonstrates how to deserialize JSON to C#
  - Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - JSON.NET form Newtonsoft (https://json.codeplex.com/)
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
@@ -28,5 +28,5 @@ The Chuck Norris Starter Kit is a XAML/C# Windows 8 app that demonstrates callin
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0

--- a/Windows Starter Kits/APIMASH_CNorris_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_CNorris_StarterKit/readme.md
@@ -1,35 +1,35 @@
-#APIMASH Chuck Norris Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar
-##URL: http://github.com/apimash/starterkits
+# APIMASH Chuck Norris Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Chuck Norris Starter Kit is a XAML/C# Windows 8 app that demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 
 [See this article for details on the Chuck Norris Starter Kit][1]
 
 ![alt text][2]
 
-###Features
+### Features
  - Invokes the Internet Chuck Norris Database API (http://www.icndb.com/)
  - Demonstrates how to deserialize JSON to C#
  - Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - JSON.NET form Newtonsoft (https://json.codeplex.com/)
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -38,8 +38,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]: http://theundocumentedapi.com/index.php/apimash-chuck-norris-starter-kit/

--- a/Windows Starter Kits/APIMASH_CNorris_VB_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_CNorris_VB_StarterKit/readme.md
@@ -1,11 +1,11 @@
-#APIMASH Chuck Norris VB Starter Kit
-##Date: 08.05.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar, ported to VB by Dave Noderer
-##URL: http://github.com/apimash/starterkits
+# APIMASH Chuck Norris VB Starter Kit
+## Date: 08.05.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar, ported to VB by Dave Noderer
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Chuck Norris Starter Kit is a XAML/VB.Net Windows 8 app that demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 
 [See this article for details on the Original Chuck Norris Starter Kit by Bob Familiar][1]
@@ -14,24 +14,24 @@ The Chuck Norris Starter Kit is a XAML/VB.Net Windows 8 app that demonstrates ca
 
 ![alt text][2]
 
-###Features
+### Features
  - Invokes the Internet Chuck Norris Database API (http://www.icndb.com/)
  - Demonstrates how to deserialize JSON to VB.NET
  - Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - JSON.NET form Newtonsoft (https://json.codeplex.com/)
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -40,8 +40,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]: http://theundocumentedapi.com/index.php/apimash-chuck-norris-starter-kit/

--- a/Windows Starter Kits/APIMASH_ESPN_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_ESPN_StarterKit/readme.md
@@ -1,31 +1,31 @@
-#APIMASH ESPN Starter Kit
-##Date: 6.24.2013
-##Version: v1.0.0
-##Author(s): Stacey Mulcahy | @bitchwhocodes
-##URL: http://github.com/apimash/starterkits
+# APIMASH ESPN Starter Kit
+## Date: 6.24.2013
+## Version: v1.0.0
+## Author(s): Stacey Mulcahy | @bitchwhocodes
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Foursquare Starter Kit uses the ESPN api and illustrates how to use many of the endpoints that do not require authorization. All calls do require an api key.
 ![My image](image.png) 
 ![My image](image1.png) 
 ![My image](image2.png) 
 ![My image](image3.png) 
 
-###Features
+### Features
  - Invokes the ESPN API (http://developer.espn.com/docs). The good folks over at Mashery support this api, so you will need to get a mashery id. 
  - Enables various endpoints without oAuth - all top news, news, fantasy football, teams, and athletes endpoints 
  - Provides a baseline for a Windows 8 Store App
  - For API documentation, please see https://developer.foursquare.com
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - Foursquare application key (apikey ) http://developer.espn.com/docs
  - Utilizes jQuery version 2.0.0 (http://code.jquery.com/jquery-2.0.0.js)
 
-###Setup
+### Setup
 
  - Register with ESPN/Mashery to get an application key
  - Keep track of the application key
@@ -35,7 +35,7 @@ The Foursquare Starter Kit uses the ESPN api and illustrates how to use many of 
  - Compile and Run
  **NOTE**: You will need to add your own developer signing certificate to the project, by opening the package.appxmanifest file, and switching to the Packaging tab. On the packaging tab, click the "Choose Certificate..." button, and in the resulting dialog, click the "Configure Certificate..." drop-down, and select "Create test certificate..." then click OK to dismiss all dialogs, and save the app manifest file.
 
-###Customization
+### Customization
 This example exposes all the endpoints at their most basic level.Some endpoints have options or parameters to help tailor the result set, please refer to the documentation from ESPN. The example provided use the defaults.  Much of the data returned is quite rich, so please look at the documentation for result information
 
 App Ideas:
@@ -43,16 +43,16 @@ App Ideas:
 - Top news updater - present the top news and by user selected sports to create a dashboard that is just for them
 - Mashup with NYTimes etc to see what other publications have deemed as news worthy in sports
 
-###Future Features
+### Future Features
 
 
 ----------
 
-##Change Log
-###v1.0.1
+## Change Log
+### v1.0.1
 - Modified readme
 
-##DISCLAIMER: 
+## DISCLAIMER: 
  
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
  

--- a/Windows Starter Kits/APIMASH_Earthquakes_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Earthquakes_StarterKit/readme.md
@@ -1,29 +1,29 @@
 ﻿#APIMASH Earthquake App
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Brian Hitney
-##URL: http://github.com/apimash/starterkits
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Brian Hitney
+## URL: http://github.com/apimash/starterkits
 
 
 ![alt text][1]
-###Description
+### Description
 This application loads earthquake data from the USGS and displays a pushpin for each earthquake on Bing maps.
 
-###Features
+### Features
 - Uses both USGS and Bing maps.
 
-###Requirements
+### Requirements
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - Bing Maps SDK for Windows Store apps - Download [here][2], and follow the instructions [here][4] for adding a reference to the SDK to your app. 
  - Bing Maps API Key (sign up [here][3] - Microsoft Account required for the Bing Maps Portal)
 
-###Setup
+### Setup
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -34,8 +34,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.1
+## Change Log
+### v1.0.1
  - Updated download links to Bing maps SDK
  - Fixed screenshot URL
 

--- a/Windows Starter Kits/APIMASH_Edmunds_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Edmunds_StarterKit/readme.md
@@ -1,23 +1,23 @@
-#APIMASH Edmunds Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar
-##URL: http://github.com/apimash/starterkits
+# APIMASH Edmunds Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar
+## URL: http://github.com/apimash/starterkits
 
 ----------
-##Description
+## Description
 The Edmunds Starter Kit is a XAML/C# Windows 8 app based on the Blank Template that demonstrates calling the Edmunds REST API's. The JSON payload for Makes, Models, Model Specs and Pictures is deserialized into a set of C# classes that define the Data Model. That data then is selectively copied into the View Model for binding to WinRT XAML controls. You can use the breadth and detail of the automotive information available through the Edmunds API to create mashups, visualizations and other applications that will provide an added dimension of user experience for the automotive consumer.
 
 Blog: [APIMASH Edmunds Starter Kit][1]
 
 ![alt text][2]
 
-##Features
+## Features
  - Invokes the [Edmunds REST API][3]
  - Demonstrates how to deserialize JSON to C# and bind to WinRT XAML Controls
  - Provides a baseline for a Windows 8 Store App
 
-##Requirements
+## Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
@@ -25,7 +25,7 @@ Blog: [APIMASH Edmunds Starter Kit][1]
  - [Mashery.com Developer Account][5]
  - [Edmunds Developer Key][6]
 
-##Setup
+## Setup
 
  - [Register at Mashery.com][7]
  - [Request a Developer Key at Edmunds][8]
@@ -35,7 +35,7 @@ Blog: [APIMASH Edmunds Starter Kit][1]
  - Update the reference to the *Newtonsoft JSON.NET Library* in the *APIMASHLib* project
  - Compile and Run
 
-##Customization
+## Customization
 
 The Edmunds API, one a scale of 1 to 10, where 1 is simple and 10 is complex, is an 11 :). Edmunds provides a rich set of API collections each with several API's and methods that give you access to Articles, Vehicle Data, Dealer info and Inventory data that can be used together or with other API's to create compelling apps.
 
@@ -93,7 +93,7 @@ The Model Year Repository API also provides these methods:
 
 You can also experiment with adding in the Editorial or Dealer API's to add color commentary and availability information.
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 

--- a/Windows Starter Kits/APIMASH_Facebook_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Facebook_StarterKit/readme.md
@@ -1,11 +1,11 @@
-#APIMASH Facebook Starter Kit
-##Date: 6.12.2013
-##Version: v1.0.0
-##Author(s): Lindsay Lindstrom, Bob Familiar (Chuck Norris Starter Kit)
-##URL: http://github.com/apimash/starterkits
+# APIMASH Facebook Starter Kit
+## Date: 6.12.2013
+## Version: v1.0.0
+## Author(s): Lindsay Lindstrom, Bob Familiar (Chuck Norris Starter Kit)
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Facebook Starter Kit is a XAML/C# Windows 8 app that leverages the Chuck Norris Starter Kit.  The Chuck Norris Starter Kit
 demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 We use the Facebook .NET SDK (http://facebooksdk.net) to customize the API call to the Chuck Norris database based on of Friend's
@@ -14,26 +14,26 @@ names and post the jokes to our Facebook feed.
 [See this article for details on the Chuck Norris Starter Kit][1]
 
 
-###Features
+### Features
  - Invokes the Internet Chuck Norris Database API (http://www.icndb.com/)
  - Demonstrates how to deserialize JSON to C#
  - Provides a baseline for a Windows 8 Store App
  - Calls to the Facebook APIs utilizing the Facebook .NET SDK
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - JSON.NET form Newtonsoft (https://json.codeplex.com/)
  - Facebook SDK for Windows (http://facebooksdk.net)
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -42,8 +42,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]: http://theundocumentedapi.com/index.php/apimash-chuck-norris-starter-kit/

--- a/Windows Starter Kits/APIMASH_Foursquare_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Foursquare_StarterKit/readme.md
@@ -1,16 +1,16 @@
-#APIMASH Foursquare Starter Kit
-##Date: 6.19.2013
-##Version: v1.0.0
-##Author(s): Stacey Mulcahy
-##URL: http://github.com/apimash/starterkits
+# APIMASH Foursquare Starter Kit
+## Date: 6.19.2013
+## Version: v1.0.0
+## Author(s): Stacey Mulcahy
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Foursquare Starter Kit uses the Foursquare api and illustrates how to use many of the endpoints that do not require authorization. All calls do require a client id however.
 ![My image](image.png) 
 ![My image](image1.png) 
 
-###Features
+### Features
  - Invokes the Foursquare API (https://developer.foursquare.com)
  - Enables various endpoints without oAuth - all venue calls ( search, get popular, categories ) 
  - Demonstrates how to use the winjs list component
@@ -18,14 +18,14 @@ The Foursquare Starter Kit uses the Foursquare api and illustrates how to use ma
  - Provides a baseline for a Windows 8 Store App
  - For API documentation, please see https://developer.foursquare.com
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - Foursquare application key ( client id ) https://developer.foursquare.com
  - Utilizes jQuery version 2.0.0 (http://code.jquery.com/jquery-2.0.0.js)
 
-###Setup
+### Setup
 
  - Register with Foursquare and register a new application ( https://developer.foursquare.com)
  - Keep track of the client id and secret once you have registered.
@@ -35,7 +35,7 @@ The Foursquare Starter Kit uses the Foursquare api and illustrates how to use ma
  - Compile and Run
  **NOTE**: You will need to add your own developer signing certificate to the project, by opening the package.appxmanifest file, and switching to the Packaging tab. On the packaging tab, click the "Choose Certificate..." button, and in the resulting dialog, click the "Configure Certificate..." drop-down, and select "Create test certificate..." then click OK to dismiss all dialogs, and save the app manifest file.
 
-###Customization
+### Customization
 This example exposes all the endpoints at their most basic level.Some endpoints have options or parameters to help tailor the result set, please refer to the documentation from Foursquare. The example provided use the defaults.  Venue information has geolocation information, so mash ups with maps, or other apis leveraging geolocation would work nicely.
 
 App Ideas:
@@ -43,16 +43,16 @@ App Ideas:
 - What is hot near you: Mash up with maps to find things near you that are popular
 - Dog Shelter finder: Search under categories for dog shelters 
 
-###Future Features
+### Future Features
 
 
 ----------
 
-##Change Log
-###v1.0.1
+## Change Log
+### v1.0.1
 - Modified readme
 
-##DISCLAIMER: 
+## DISCLAIMER: 
  
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
  

--- a/Windows Starter Kits/APIMASH_Instagram_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Instagram_StarterKit/readme.md
@@ -1,16 +1,16 @@
-#APIMASH Instagram Starter Kit
-##Date: 6.19.2013
-##Version: v1.0.0
-##Author(s): Stacey Mulcahy
-##URL: http://github.com/apimash/starterkits
+# APIMASH Instagram Starter Kit
+## Date: 6.19.2013
+## Version: v1.0.0
+## Author(s): Stacey Mulcahy
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Instagram Starter Kit uses the Instagram api and illustrates how to use many of the endpoints that do not require authorization. All calls do require a client id however.
 ![My image](image.png) 
 ![My image](image1.png) 
 ![My image](image2.png) 
-###Features
+### Features
  - Invokes the Instagram API (http://instagram.com/developer/)
  - Enables various endpoints including tags, location, media and popular. 
  - Demonstrates how to use the winjs list component
@@ -18,14 +18,14 @@ The Instagram Starter Kit uses the Instagram api and illustrates how to use many
  - Provides a baseline for a Windows 8 Store App
  - For API documentation, please see http://instagram.com/developer/
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - Instagram application key ( client id ) http://instagram.com/developer/
  - Utilizes jQuery version 2.0.0 (http://code.jquery.com/jquery-2.0.0.js)
 
-###Setup
+### Setup
 
  - Register with Instagram and register a new application ( http://instagram.com/developer/clients/manage/)
  - Keep track of the client id once you have registered.
@@ -35,7 +35,7 @@ The Instagram Starter Kit uses the Instagram api and illustrates how to use many
  - Compile and Run
  **NOTE**: You will need to add your own developer signing certificate to the project, by opening the package.appxmanifest file, and switching to the Packaging tab. On the packaging tab, click the "Choose Certificate..." button, and in the resulting dialog, click the "Configure Certificate..." drop-down, and select "Create test certificate..." then click OK to dismiss all dialogs, and save the app manifest file.
 
-###Customization
+### Customization
 This example exposes all the endpoints at their most basic level. Most of the endpoints do not have options, but a few do that include things like distance( for geolocation) or the max and min ideas for any endpoint that is getting recent media. Please see the Instagram API documentation - these parameters can be passed in through the calls via the options parameter, which is an object. 
 
 As some photos do carry geolocation information with them ( its a user's preference to add geolocation), mash ups with Maps are ideal. This template also provides and easy way to aggregate and show photos tagged with a specific hashtag, or that are in a location - making it an ideal complement to apis such as Yelp, Foursquare and Meetup to name a few. 
@@ -47,16 +47,16 @@ App Ideas:
 - InstaMap : Map locations and show photos taken in that location. Show who is the most prolific photographer. 
 - Instatour - create a tour of an area through instagram photos
 
-###Future Features
+### Future Features
 
 
 ----------
 
-##Change Log
-###v1.0.1
+## Change Log
+### v1.0.1
 - Modified readme
 
-##DISCLAIMER: 
+## DISCLAIMER: 
  
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
  

--- a/Windows Starter Kits/APIMASH_MeetupPOI_StarterKit/APIMASH_MeetupPOI_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_MeetupPOI_StarterKit/APIMASH_MeetupPOI_StarterKit/readme.md
@@ -1,16 +1,16 @@
-#Meetup/Bing Maps Starter Kit
-##Date: 05/08/2013
-##Version: v0.0.2
-##Author(s): G. Andrew Duthie
-##URL: http://github.com/apimash/starterkits
+# Meetup/Bing Maps Starter Kit
+## Date: 05/08/2013
+## Version: v0.0.2
+## Author(s): G. Andrew Duthie
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Meetup/Bing Maps Starter Kit is a native HTML5 and JavaScript Windows Store app based on the Grid App template. It leverages the Meetup.com API to search for upcoming meetups near a given location, with optional keyword filtering. Once the meetups are retrieved, the starter kit maps a selected item, and queries the Bing Maps Search API for nearby coffee shops, and maps those as well.
 
 ![alt text][1]
 
-###Features
+### Features
  - Demonstrates using WinJS.xhr to call the [Meetup.com API][2]
  - Demonstrates integrating Bing Maps, and calling the Bing Maps Search API
  - Demonstrates how to load live data into the JavaScript Grid App template, and how to adapt the live data to display with minimal customization to the HTML and JavaScript files in the template
@@ -18,13 +18,13 @@ The Meetup/Bing Maps Starter Kit is a native HTML5 and JavaScript Windows Store 
  - Demonstrates the use of the Settings contract to provide About and Privacy pages
  - Demonstrates the use of the Share Source contract, to easily share app content with other installed apps
 
-###Requirements
+### Requirements
  - Meetup API Key (don't use your day-to-day meetup ID for this...create a unique account, and sign up for a key [here][3])
  - Bing Maps SDK for Windows Store apps - Download [here][4], and follow the instructions [here][5] for adding a reference to the SDK to your app. 
  - Bing Maps API Key (sign up [here][6] - Microsoft Account required for the Bing Maps Portal)
  - Windows Store Account (to submit app for certification)
 
-###Setup and Customization
+### Setup and Customization
 Basic customization is done via the file customizeMe.js, found in the js folder. Here are the key items you can customize:
 
  - meetupKey: Your custom Meetup API key
@@ -41,13 +41,13 @@ Basic customization is done via the file customizeMe.js, found in the js folder.
  
 More advanced customization is possible by digging into the code and stylesheets. All logic for retrieving and grouping Meetup data may be found in js/meetupData.js. App-wide styles may be found in css/default.css, and page-specific styles may be found in each respective page folder.
 
-###Known Issues
+### Known Issues
 Here are the currently known issues (aka learning opportunities for the developer):
 
  - Snapped View: Snapped view is partially implemented (via the CSS media queries from the Grid App template), but the snapped view will need to be improved prior to submitting an app for the Windows Store.
  - App Images: Splash Screen, app tile logos, etc. need to be provided prior to submitting an app based on this starter kit for certification in the Windows Store
 
-##**DISCLAIMER**: 
+## **DISCLAIMER**: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -57,8 +57,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v0.0.2
+## Change Log
+### v0.0.2
 
  - Added license information to all source files
 

--- a/Windows Starter Kits/APIMASH_MeetupPOI_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_MeetupPOI_StarterKit/readme.md
@@ -1,16 +1,16 @@
-#Meetup/Bing Maps Starter Kit
-##Date: 05/08/2013
-##Version: v0.0.2
-##Author(s): G. Andrew Duthie
-##URL: http://github.com/apimash/starterkits
+# Meetup/Bing Maps Starter Kit
+## Date: 05/08/2013
+## Version: v0.0.2
+## Author(s): G. Andrew Duthie
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Meetup/Bing Maps Starter Kit is a native HTML5 and JavaScript Windows Store app based on the Grid App template. It leverages the Meetup.com API to search for upcoming meetups near a given location, with optional keyword filtering. Once the meetups are retrieved, the starter kit maps a selected item, and queries the Bing Maps Search API for nearby coffee shops, and maps those as well.
 
 ![alt text][1]
 
-###Features
+### Features
  - Demonstrates using WinJS.xhr to call the [Meetup.com API][2]
  - Demonstrates integrating Bing Maps, and calling the Bing Maps Search API
  - Demonstrates how to load live data into the JavaScript Grid App template, and how to adapt the live data to display with minimal customization to the HTML and JavaScript files in the template
@@ -18,13 +18,13 @@ The Meetup/Bing Maps Starter Kit is a native HTML5 and JavaScript Windows Store 
  - Demonstrates the use of the Settings contract to provide About and Privacy pages
  - Demonstrates the use of the Share Source contract, to easily share app content with other installed apps
 
-###Requirements
+### Requirements
  - Meetup API Key (don't use your day-to-day meetup ID for this...create a unique account, and sign up for a key [here][3])
  - Bing Maps SDK for Windows Store apps - Download [here][4], and follow the instructions [here][5] for adding a reference to the SDK to your app. 
  - Bing Maps API Key (sign up [here][6] - Microsoft Account required for the Bing Maps Portal)
  - Windows Store Account (to submit app for certification)
 
-###Setup and Customization
+### Setup and Customization
 Basic customization is done via the file customizeMe.js, found in the js folder. Here are the key items you can customize:
 
  - meetupKey: Your custom Meetup API key
@@ -41,13 +41,13 @@ Basic customization is done via the file customizeMe.js, found in the js folder.
  
 More advanced customization is possible by digging into the code and stylesheets. All logic for retrieving and grouping Meetup data may be found in js/meetupData.js. App-wide styles may be found in css/default.css, and page-specific styles may be found in each respective page folder.
 
-###Known Issues
+### Known Issues
 Here are the currently known issues (aka learning opportunities for the developer):
 
  - Snapped View: Snapped view is partially implemented (via the CSS media queries from the Grid App template), but the snapped view will need to be improved prior to submitting an app for the Windows Store.
  - App Images: Splash Screen, app tile logos, etc. need to be provided prior to submitting an app based on this starter kit for certification in the Windows Store
 
-##**DISCLAIMER**: 
+## **DISCLAIMER**: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -57,8 +57,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v0.0.2
+## Change Log
+### v0.0.2
 
  - Added license information to all source files
 

--- a/Windows Starter Kits/APIMASH_MessierSkyObjects_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_MessierSkyObjects_StarterKit/readme.md
@@ -1,27 +1,27 @@
 ﻿#APIMASH Messier Object Explorer
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Brian Hitney
-##URL: http://github.com/apimash/starterkits
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Brian Hitney
+## URL: http://github.com/apimash/starterkits
 
 
 ![alt text][1]
-###Description
+### Description
 This application embeds the Worldwide Telescope HTML JavaScript SDK into a Windows 8 application.   A collection of sky objects (called the Messier Catalog) is bound to a list, and allows the user to explorer these objects in the sky.
 
-###Features
+### Features
 - Uses Worldwide Telescope!
 
-###Requirements
+### Requirements
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
 
-###Setup
+### Setup
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -32,8 +32,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 
 
   [1]: https://raw.github.com/apimash/StarterKits/master/Windows%20Starter%20Kits/APIMASH_MessierSkyObjects_StarterKit/screenshot.png "Screenshot"

--- a/Windows Starter Kits/APIMASH_RottenTomatoes_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_RottenTomatoes_StarterKit/readme.md
@@ -1,22 +1,22 @@
-#APIMASH Rotten Tomatoes Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Bob Familiar
-##URL: http://github.com/apimash/starterkits
+# APIMASH Rotten Tomatoes Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Bob Familiar
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Rotten Tomatoes Starter Kit is a XAML/C# Windows 8 app based on the Grid Template that demonstrates calling the Rotten Tomatoes REST API's. The JSON payload for Movies or DVD's is deserialized into a set of C# classes that define the Data Model. That data then is selectively copied into the View Model for binding to the WinRT XAML controls.
 
 Blog: [APIMASH Rotten Tomatoes Starter Kit][1]
 
 ![alt text][2]
-###Features
+### Features
  - Invokes the Rotten Tomatoes REST API (http://developer.rottentomatoes.com/)
  - Demonstrates how to deserialize JSON to C# and bind to WinRT XAML Controls
  - Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
@@ -25,7 +25,7 @@ Blog: [APIMASH Rotten Tomatoes Starter Kit][1]
  - Mashery.com Developer Account (http://developer.mashery.com/)
  - Rotten Tomatoes Developer Key (http://developer.rottentomatoes.com/)
 
-###Setup
+### Setup
 
  - Register at Mashery.com (http://developer.mashery.com/)
  - Request a Developer Key from Rotten Tomatoes (http://developer.rottentomatoes.com/)
@@ -35,7 +35,7 @@ Blog: [APIMASH Rotten Tomatoes Starter Kit][1]
  - Update the reference to the Newtonsoft JSON.NET Library in the APIMASHLib project
  - Compile and Run
 
-###Customization
+### Customization
 
 Step 1. Add your Developer Key in the *Globals.cs* source file on line 20
 
@@ -68,7 +68,7 @@ Step 3. You can modify the parameters to each query such as the limit of the num
 
 Step 4. Movie information is EXTREMELY mashable! Experiment by combining Rotten Tomatoes with Bing Maps showing nearby movie theaters (check out [the Bing Map Starter Kit][5]!)
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 

--- a/Windows Starter Kits/APIMASH_StackExchange_StarterKit/Readme.md
+++ b/Windows Starter Kits/APIMASH_StackExchange_StarterKit/Readme.md
@@ -1,34 +1,34 @@
-#APIMASH StackExchange Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Michael Cummings
-##URL: http://github.com/apimash/starterkits
+# APIMASH StackExchange Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Michael Cummings
+## URL: http://github.com/apimash/starterkits
 
 ----------
-##Description
+## Description
 The StackExchange Starter Kit is a XAML/C# Windows 8 app based on the Blank Template that demonstrates calling the StackExchange REST API's. The JSON payload for Questions, Answers, Comments, Users is deserialized into a set of C# classes that define the Data Model. That data then is selectively copied into the View Model for binding to WinRT XAML controls. You can use the breadth and detail of the discussion information available through the StackExchange API to create mashups, visualizations and other applications that will provide an added dimension of user experience for the answer seeker.
 
 ![alt text][1001]
 
-##Features
+## Features
  - Invokes the [StackExchange REST API][1002]
  - Demonstrates how to deserialize compressed JSON to C# and bind to WinRT XAML Controls
  - Provides a baseline for a Windows 8 Store App
 
-##Requirements
+## Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - [JSON.NET from Newtonsoft][1003]
  - [HTML Agility Pack][1005]
 
-##Setup
+## Setup
 
  - [Download the Starter Kit Zip Portfolio][1004] 
  - Open the Solution in Visual Studio
  - Compile and Run
 
-##Customization
+## Customization
 
 The StackExchange API, one a scale of 1 to 10, where 1 is simple and 10 is complex, is an 9 :). StackExchange provides a rich set of API collections each with several API's and methods that give you access to Questions, Answers, Comments, Users, and Tags that can be used together or with other API's to create compelling apps.
 
@@ -493,7 +493,7 @@ These methods return data across the entire Stack Exchange network of sites. Acc
 
 You can also experiment with adding in the Editorial or Dealer API's to add color commentary and availability information.
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 

--- a/Windows Starter Kits/APIMASH_TomTom_BingMaps_StarterKit/README.md
+++ b/Windows Starter Kits/APIMASH_TomTom_BingMaps_StarterKit/README.md
@@ -1,22 +1,22 @@
-#APIMASH TomTom/BingMaps Starter Kit
-##Date: 7.13.2013
-##Version: v1.0.4
-##Author(s): Jim O'Neil
-##URL: http://github.com/apimash/starterkits
+# APIMASH TomTom/BingMaps Starter Kit
+## Date: 7.13.2013
+## Version: v1.0.4
+## Author(s): Jim O'Neil
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The TomTom/BingMaps Starter Kit is a XAML/C# Windows Store application that demonstrates a mashup of BingMaps with the Traffic Cams API provided by [TomTom][10].  The application has been built to easily overlay and display locality-based information obtained from other APIs.
 
 ![Traffic Cam application](screenshot.png)
 
-###Features
+### Features
  - Incorporates [Bing Maps for Windows Store][2] control and invokes a the [Bing Maps Find a Location by Query REST API][3]
  - Invokes the [TomTom Traffic Cameras API][1]
  - Demonstrates how to deserialize both XAML and JSON to C#
  - Provides a baseline for a Windows Store App
 
-###Requirements
+### Requirements
 
  - Windows 8
  - [Visual Studio 2012 Express for Windows 8][6] or higher
@@ -24,7 +24,7 @@ The TomTom/BingMaps Starter Kit is a XAML/C# Windows Store application that demo
  - [JSON.NET][8]
  - [Mashery ID to access TomTom Developer Portal][9] and obtain API license key
 
-###Setup
+### Setup
 
  - Download the [Starter Kit Zip Portfolio][5] 
  - Navigate to the **APIMASH\_TomTom\_BingMaps\__StarterKit** directory and open the solution there
@@ -35,7 +35,7 @@ The TomTom/BingMaps Starter Kit is a XAML/C# Windows Store application that demo
     ![Build Configuration](config.PNG)
   - Paste your Bing Maps API and TomTom Traffic Cam API keys into designated portion of the **App.xaml** file
 
-###Customization
+### Customization
 This starter kit was built in a modular manner to make it easy to integrate just about any API that has elements exposing latitude and longitude. The Bing Maps implementation already includes necessary 
 logic for showing point-of-interest pins, marking your current location as determined by GPS, and allowing a location search via a flyout accessible from the App Bar. The Search contract is also already
 implemented with a landing pages showing the results and a static map snippet for each location found.
@@ -50,7 +50,7 @@ be used to further customize the code.  At a high level, you'll need to minimall
 Upon store submission, you will need to create separate packages for each of the target architectures (ARM, x86, and x64) due to the reliance of the Bing Maps
 control on a native C++ layer.
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -58,7 +58,7 @@ Microsoft and I do not warrant, guarantee or make any representations regarding 
 Microsoft and I shall not be liable for any direct, indirect or consequential damages or costs of any type arising out of any action taken by you or others related to the sample code.
 
 
-###Change Log
+### Change Log
 
 1.0.1: added more detail to the Setup section and added Customization guidance
 

--- a/Windows Starter Kits/APIMASH_Tumblr/readme.md
+++ b/Windows Starter Kits/APIMASH_Tumblr/readme.md
@@ -1,35 +1,35 @@
-#APIMASH Tumblr Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.1
-##Author(s): Stacey Mulcahy 
-##URL: http://github.com/apimash/starterkits
+# APIMASH Tumblr Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.1
+## Author(s): Stacey Mulcahy 
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Tumblr Daily Lawls App is an application that shows how to call a web service ( tumblr ) and present a UI based on the data.
 ![Alt text](https://nkz01w.dm1.livefilestore.com/y2pQ9n58fsXoTpY_laEYMY2uIsg8n3frMHpD08vrR4vjL3OeFpNYWTYGb_HqpoyxZXjwzlqXnvublW2sBMtdmHEifHesHsf8mR4-Nrl4xJdeXw/APIMash_Tumblr.png?psid=1)
-###Features
+### Features
  - Invokes the Tumblr API (http://www.tumblr.com/docs/en/api/v2), specifically the tags endpoint
  - Demonstrates how to download an image to the pictures directory
  - Demonstrates how to write a file to the local application directory ( cacheing of data)
  - Provides a baseline for a Windows 8 Store App
  - Sample result call can be seen in the browser via this url http://api.tumblr.com/v2/tagged?tag=gif&api_key=[YOUR_APP_KEY]
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - Tumblr API Developer key (http://www.tumblr.com/oauth/apps ) 
  - Utilizes jQuery version 2.0.0 (http://code.jquery.com/jquery-2.0.0.js)
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from http://apimash.github.io/StarterKits/
  - Open the Solution in Visual Studio
  - Compile and Run
  **NOTE**: You will need to add your own developer signing certificate to the project, by opening the package.appxmanifest file, and switching to the Packaging tab. On the packaging tab, click the "Choose Certificate..." button, and in the resulting dialog, click the "Configure Certificate..." drop-down, and select "Create test certificate..." then click OK to dismiss all dialogs, and save the app manifest file.
 
-###Customization
+### Customization
 What is being searched for from the Tumblr api can be changed. In this example, "lol" and "gifs" are being searched for. Two ways exist to change
 these parameters.
 - Modify the developer key, which you will need to get from Tumblr.(http://www.tumblr.com/docs/en/api/v2)
@@ -37,16 +37,16 @@ these parameters.
 - Modify the call to get the data in tumblr.js to pass an array of tags you would like to search for
 - The UI and overall experience can easily be changed by writing your own view logic in tumblr.js - replacing what is there. 
 
-###Future Features
+### Future Features
  - Include OAuth and OAuth related endpoints 
 
 ----------
 
-##Change Log
-###v1.0.1
+## Change Log
+### v1.0.1
 - Modified readme
 
-##DISCLAIMER: 
+## DISCLAIMER: 
  
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
  

--- a/Windows Starter Kits/APIMASH_Twitter_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Twitter_StarterKit/readme.md
@@ -1,14 +1,14 @@
-#APIMASH Twitter Starter Kit
-##Date: 05.30.2013
-##Version: v2.0.0
-##Author(s): Tara E. Walker
-##http://github.com/apimash/starterkits
+# APIMASH Twitter Starter Kit
+## Date: 05.30.2013
+## Version: v2.0.0
+## Author(s): Tara E. Walker
+## http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Twitter Starter Kit is an XAML/C# Windows 8 application using a lite MVVM commanding pattern that demonstrates how to call various Twitter REST APIs.  Each call returns a JSON payload that is then deserialized into a observable collection of set of C# classes that are derived from the Model (Data Model).  That observable collection is returned to the View Model and data therein is displayed via data binding of elements to the WinRT Xaml control.
 
-###ScreenShots
+### ScreenShots
 App on Start Screen
 
 ![alt text][1]
@@ -37,7 +37,7 @@ User Followers
 
 ![alt text][7]
 
-###Features
+### Features
  - Retrieves and creates OAuth required token and signatures to call Twitter OAuth required REST API
  - Can retrieve authorized user Home Timeline
  - Can retrieve any timeline of statuses per user screen name entered (as long as not protected)
@@ -45,7 +45,7 @@ User Followers
  - Can search on keyword or user to return associated tweets
  - Can return followers by user, if no user is specified will return followers by authorized user
 
-###Requirements
+### Requirements
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - JSON.NET form Newtonsoft (https://json.codeplex.com/)
@@ -53,7 +53,7 @@ User Followers
  - Twitter Consumer Key and Consumer Secret (http://dev.twitter.com/)
  - List item
 
-###Setup
+### Setup
  1. Create an application record (which includes an API key) by navigating to https://dev.twitter.com/apps . Most integrations with the API will require you to identify your application to Twitter by way of an API key. On the Twitter platform, the term "API key" usually refers to  combination of two keys; an OAuth consumer key and the consumer secret.
  2. Download the Starter Kit Zip Portfolio from ([http://apimash.github.io/StarterKits/][8])
  3. Open the ***APIMASH_TwitterAPI_StarterKit*** Solution in Visual Studio 2012
@@ -61,7 +61,7 @@ User Followers
  5. Compile and Run
  6. You or user of app will be asked to authorize the app for use in obtaining Twitter information the first time of application is used.
 
-###Customization
+### Customization
 
 ***Step 1***. Add your Consumer Key and Consumer Secret in the App.xaml source file
  
@@ -96,7 +96,7 @@ as a placeholder for customization by users of the Starter kit, the Twitter API 
 ***Step 10.*** Mash up Twitter Tweets with FaceBook to have apps post to both simultaneously (check out the Facebook Starter Kit)
 
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -107,10 +107,10 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
 Initial Twitter Starter Kit loaded to GitHub
-###v2.0.0
+### v2.0.0
 Updated the Twitter Starter Kit UI significantly, added feature to Get a specific User followers, added App Bar 
 
 

--- a/Windows Starter Kits/APIMASH_Univision_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_Univision_StarterKit/readme.md
@@ -1,31 +1,31 @@
-#Title APIMASH Univision Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Diego Lizarazo R.
-##URL: http://github.com/apimash/starterkits
+# Title APIMASH Univision Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Diego Lizarazo R.
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Univision API test is a XAML/C# Windows 8 app that demonstrates calling a Web Service that returned a simple XML payload from one of the best Spanish-language content and services provider.
 
 ![alt text][1]
 
-###Features
+### Features
 • Invokes the Internet Univision API (http://developer.univision.com/)
 • Demonstrates how to add XML feeds to C#
 • Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 • Windows 8
 • Visual Studio 2012 Express for Windows 8 or higher
 
 
-###Setup
+### Setup
 • Download the Starter Kit Zip Portfolio from  http://apimash.github.io/StarterKits/ 
 • Open the Solution in Visual Studio
 • Compile and Run
 
-###Customization
+### Customization
 
 Step 1. Add your Developer Key in the Globals.cs source file on line 20
 
@@ -43,7 +43,7 @@ Step 4. Gossip information is EXTREMELY  mashable! Experiment by combining Univi
 
 
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 
@@ -54,8 +54,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v0.0.0
+## Change Log
+### v0.0.0
 Add version data here
 
 

--- a/Windows Starter Kits/APIMASH_WikiPedia_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_WikiPedia_StarterKit/readme.md
@@ -1,28 +1,28 @@
-#Title: Wikipedia Geonames APIMASH
-##Date: 2013-05-15
-##Version: v1.0.0
-##Author:  Joe Healy 
-##URL: http://bit.ly/apimash
-##License: Microsoft Public License - http://opensource.org/licenses/ms-pl
-###Description
+# Title: Wikipedia Geonames APIMASH
+## Date: 2013-05-15
+## Version: v1.0.0
+## Author:  Joe Healy 
+## URL: http://bit.ly/apimash
+## License: Microsoft Public License - http://opensource.org/licenses/ms-pl
+### Description
 Geonames has an easy to access API that exposes Wikipedia articles that are georeferenced.  This sample code shows how to easily access the Wikipedia Webservice on geonames. 
 Questions, concerns, comments please relay to jhealy@microsoft.com // josephehealy@hotmail.com // @devfish on twitter ...
 
-###Features
+### Features
  - findNearbyWikipedia - finds nearby Wikipedia entries by radius, and by latitude/longitude OR postal code
  - wikipediaSearch - Search for a place name and optionally text from the title of the article
  - wikipediaBoundingBox - Search for entries within a south, north, east, and west latitude and longitude bounded box
  - User name is stored in isolated storage between sessions.  No editing .cs or .js files to get it to run
  - XAML and CSharp only at this time.  More consumption samples in other languages coming soon
 
-###Requirements
+### Requirements
 What do you need to run this project? 
 - Windows 8
 - Visual Studio 2012 Express for Windows 8 or higher
 - JSON.NET form Newtonsoft (https://json.codeplex.com/)
 - Geonames login for the web service API ( http://www.geonames.org/login )
 
-###Setup
+### Setup
 - Register at Geonames.org (  http://www.geonames.org/login )
 - Download the Starter Kit Zip Portfolio from ( http://bit.ly/apimash )
 - Open the Solution in Visual Studio
@@ -30,16 +30,16 @@ What do you need to run this project?
 - Go to the Settings => User Name menu and enter your user name (first time only)
 - Compile and Run
 
-###Customization
+### Customization
 Step 1. Modify the calls to geonames helpers to 'mash in' with any input params you want.
 Step 2. Geonames Wikipedia information is EXTREMELY  mashable! Experiment by combining Geonames Wikipedia with Bing Maps showing nearby points of interest (check out the Bing Map Starter Kit at http://bit.ly/apimash to see how to use Bing Maps)
 
-##Change Log
-###v1.0.0 Initial release with simple text output for apis, no parameter screens yet
-###v1.0.0.1 License changed to bobfam %20 special version
-###v1.0.0.2 Moved APIMASHLib local to main wikipedia project.  Bad practice but when in rome...
+## Change Log
+### v1.0.0 Initial release with simple text output for apis, no parameter screens yet
+### v1.0.0.1 License changed to bobfam %20 special version
+### v1.0.0.2 Moved APIMASHLib local to main wikipedia project.  Bad practice but when in rome...
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
 Microsoft and I shall not be liable for any direct, indirect or consequential damages or costs of any type arising out of any action taken by you or others related to the sample code.

--- a/Windows Starter Kits/APIMASH_WorldOfWarcraft_StarterKit/readme.md
+++ b/Windows Starter Kits/APIMASH_WorldOfWarcraft_StarterKit/readme.md
@@ -1,18 +1,18 @@
-#APIMASH Windows 8 World of Warcraft API Kit
-##Date: 5.9.2013
-##Version: v1.0.0
-##Author(s): David Isbitksi
-##URL: http://github.com/apimash/starterkits
+# APIMASH Windows 8 World of Warcraft API Kit
+## Date: 5.9.2013
+## Version: v1.0.0
+## Author(s): David Isbitksi
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Windows 8 World of Warcraft API Kit is intended to teach Windows developers how to incorporate the World of Warcraft APIs into their own apps.
 This Kit is for educational and entertainment purposes only.  World of Warcraft is a very successful online game from Blizzard Entertainment®.   
 Blizzard Entertainment® is the copyright holder to all World of Warcraft content and images used in this application.
 Blizzard Entertainment® is the owner of the World of Warcraft API which can be found at http://blizzard.github.io/api-wow-docs/.
 
 ![alt text][1]
-###Features
+### Features
 WoW API
   - Realm Status (individual)
   - Realm Status (all)
@@ -24,18 +24,18 @@ Windows Store App
   - Settings Panel
   - Icons
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
 
-###Setup
+### Setup
 
  - Download the Starter Kit Zip Portfolio from (http://apimash.github.io/StarterKits/)
  - Open the Solution in Visual Studio
  - Compile and Run
 
-###Customization
+### Customization
 
 Step 1. All of the Blizzard World of Warcraft API's do not require a developer key to use.  However, if you plan on creating an application with heavy api usage Blizzard requests you contact them at api-support@blizzard.com to register your application.
 
@@ -45,7 +45,7 @@ Step 3. Once you have data returning you should bind to a listview in the same m
 
 Step 4. It is highly recommend you use WinJS page controls to follow standard convention.  Simply create a new folder in the root of the project, right click and add a new "Page Control".  Then edit the html, css, and js in the same manner that was done in the /realmstatus page control.
 
-##DISCLAIMER: 
+## DISCLAIMER: 
 
 The sample code described herein is provided on an "as is" basis, without warranty of any kind, to the fullest extent permitted by law. Both Microsoft and I do not warrant or guarantee the individual success developers may have in implementing the sample code on their development platforms or in using their own Web server configurations. 
 Microsoft and I do not warrant, guarantee or make any representations regarding the use, results of use, accuracy, timeliness or completeness of any data or information relating to the sample code. Microsoft and I disclaim all warranties, express or implied, and in particular, disclaims all warranties of merchantability, fitness for a particular purpose, and warranties related to the code, or any service or software related thereto. 
@@ -60,8 +60,8 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0 - Updated to point to new license file
+## Change Log
+### v1.0.0 - Updated to point to new license file
 
 
   [1]: https://raw.github.com/apimash/StarterKits/master/Windows%20Starter%20Kits/APIMASH_WorldOfWarcraft_StarterKit/wowapikit_1366x768.png "Windows 8 Wow API Starter Kit"

--- a/Windows Starter Kits/APIMASH_Yelp_StarterKit/Readme.md
+++ b/Windows Starter Kits/APIMASH_Yelp_StarterKit/Readme.md
@@ -1,29 +1,29 @@
-#APIMASH Yelp Starter Kit
-##Date: 5.10.2013
-##Version: v1.0.0
-##Author(s): Chris Bowen
-##URL: http://github.com/apimash/starterkits
+# APIMASH Yelp Starter Kit
+## Date: 5.10.2013
+## Version: v1.0.0
+## Author(s): Chris Bowen
+## URL: http://github.com/apimash/starterkits
 
 ----------
-###Description
+### Description
 The Yelp Starter Kit is a XAML-based Windows 8 app that demonstrates calling a Web Service that returned a simple JSON payload. The JSON payload is deserialized into a View Model.
 
 ![Yelp Starter Kit Screenshot][1] 
 
-###Features
+### Features
  - Invokes the Yelp API (http://www.yelp.com/developers)
  - Demonstrates how to deserialize JSON to C#
  - Uses a binding object model for data binding to UI
  - Provides a baseline for a Windows 8 Store App
 
-###Requirements
+### Requirements
 
  - Windows 8
  - Visual Studio 2012 Express for Windows 8 or higher
  - JSON.NET from Newtonsoft (https://json.codeplex.com/)
  - Yelp API Developer Key (http://www.yelp.com/developers)
 
-###Setup
+### Setup
 
  - Request a Developer Key from Yelp (http://www.yelp.com/developers)
  - Download the Starter Kit Zip Portfolio from (http://apimash.github.io/StarterKits/)
@@ -34,7 +34,7 @@ The Yelp Starter Kit is a XAML-based Windows 8 app that demonstrates calling a W
  - Add your Developer Key MainPage.xaml.cs, replacing the [YOUR-DEV-KEY-HERE] placeholder
  - Compile and Run
 
-###DISCLAIMER: 
+### DISCLAIMER: 
 
 This sample is licensed under the Microsoft Public License (MS-PL) - http://opensource.org/licenses/ms-pl
 
@@ -45,7 +45,7 @@ Microsoft and I shall not be liable for any direct, indirect or consequential da
 
 ----------
 
-##Change Log
-###v1.0.0
+## Change Log
+### v1.0.0
   
   [1]: https://raw.github.com/apimash/StarterKits/master/APIMASH_Yelp_StarterKit/screenshot_main.png "Yelp Starter Kit Screenshot" 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
